### PR TITLE
added rex/php min version check

### DIFF
--- a/install.inc.php
+++ b/install.inc.php
@@ -10,6 +10,8 @@
  * file that was distributed with this source code.
  */
 
+$msg = '';
+
 $minPhpVersion = '5.4.0';
 $minRexVersion = '4.6.0';
 if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {

--- a/install.inc.php
+++ b/install.inc.php
@@ -10,4 +10,17 @@
  * file that was distributed with this source code.
  */
 
-$REX['ADDON']['install']['yconverter'] = true;
+$minPhpVersion = '5.4.0';
+$minRexVersion = '4.6.0';
+if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
+    $msg = 'Es wird mindestens PHP '. $minPhpVersion .' benötigt!';
+} elseif (version_compare($REX['VERSION'] . '.' . $REX['SUBVERSION'] . '.' . $REX['MINORVERSION'], $minRexVersion) < 0) {
+    $msg = 'Es wird mindestens REDAXO '. $minRexVersion .' benötigt!';
+}
+
+if ($msg != '') {
+    $REX['ADDON']['installmsg']['yconverter'] = $msg;
+    $REX['ADDON']['install']['yconverter'] = false;
+} else {
+    $REX['ADDON']['install']['yconverter'] = true;
+}


### PR DESCRIPTION
refs https://github.com/yakamara/yconverter/issues/15

mal als anfang... falls wir mit einem separaten PR das addon erweitern damit es auch mit älteren rex versionen geht, kann man es ja nachpflegen.

Code im "developer_rex4" geklaut.