### PR TITLE
Weitere Ersetzungen hinzugefügt

### DIFF
--- a/lib/YConverter/Converter.php
+++ b/lib/YConverter/Converter.php
@@ -89,6 +89,7 @@ class Converter
                     ['OOArticle\s*::\s*getArticleById\(' => 'rex_article::get('],
                     ['OOCategory\s*::\s*getCategoryById\(' => 'rex_category::get('],
                     ['OOMedia\s*::\s*getMediaByFilename\(' => 'rex_media::get('],
+                    ['OOMedia\s*::\s*getMediaByName\(' => 'rex_media::get('],
                     ['OOMediaCategory\s*::\s*getCategoryById\(' => 'rex_media_category::get('],
                     ['OOAddon\s*::\s*isActivated\((.*?)\)' => 'rex_addon::get($1)->isActivated()'],
                     ['OOAddon\s*::\s*isAvailable\((.*?)\)' => 'rex_addon::get($1)->isAvailable()'],
@@ -182,12 +183,21 @@ class Converter
                     ['rex_title\(' => 'rex_view::title('],
                     ['rex_translate\(' => 'rex_i18n::translate('],
                     ['rex_warning\(' => 'rex_view::error('],
+                    ['OOArticle' => 'rex_article'],
+                    ['OOCategory' => 'rex_category'],
+                    ['OOMedia' => 'rex_media'],
+                    ['OOMediaCategory' => 'rex_media_category'],
                 ]
             ], [
                 // XForm
                 'replaces' => [
                     ['db2email' => 'tpl2email'],
                     ['notEmpty' => 'empty'],
+                ]
+            ], [
+                // SEO42
+                'replaces' => [
+                    ['seo42\s*::\s*getMediaFile\(' => 'rex_url::media('],
                 ]
             ],
         ];

--- a/lib/YConverter/Converter.php
+++ b/lib/YConverter/Converter.php
@@ -183,10 +183,10 @@ class Converter
                     ['rex_title\(' => 'rex_view::title('],
                     ['rex_translate\(' => 'rex_i18n::translate('],
                     ['rex_warning\(' => 'rex_view::error('],
-                    ['OOArticle' => 'rex_article'],
-                    ['OOCategory' => 'rex_category'],
-                    ['OOMedia' => 'rex_media'],
-                    ['OOMediaCategory' => 'rex_media_category'],
+                    ['instanceof\s*OOArticle' => 'instanceof rex_article'],
+                    ['instanceof\s*OOCategory' => 'instanceof rex_category'],
+                    ['instanceof\s*OOMedia' => 'instanceof rex_media'],
+                    ['instanceof\s*OOMediaCategory' => 'instanceof rex_media_category'],
                 ]
             ], [
                 // XForm

--- a/lib/YConverter/Converter.php
+++ b/lib/YConverter/Converter.php
@@ -198,6 +198,8 @@ class Converter
                 // SEO42
                 'replaces' => [
                     ['seo42\s*::\s*getMediaFile\(' => 'rex_url::media('],
+                    ['seo42\s*::\s*getLangCode\((.*?)\)' => 'rex_clang::getCurrent()->getCode()'],
+                    ['seo42\s*::\s*getBaseUrl\((.*?)\)' => 'rex::getServer()'],
                 ]
             ],
         ];


### PR DESCRIPTION
Folgende Änderungen:
- OOMedia::getMediaByName() wird jetzt ersetzt
- SEO42 Ersetzungen hinzugefügt (zur Zeit nur eine Ersetzung)
- Klassennamen OOArticle, OOCategory, OOMedia, OOMediaCategory einzeln ersetzen, wenn z.B. im Modul früher "instanceof OOMedia" o.ä. verwendet wurde.