### PR TITLE
regex für mehrzeiligen heuhaufen anpassen

### DIFF
--- a/lib/YConverter/Converter.php
+++ b/lib/YConverter/Converter.php
@@ -922,7 +922,7 @@ class Converter
                 for ($i = 1; $i <= 20; $i++) {
                     $column = 'value' . $i;
                     // Notices bei unserialize vermeiden
-                    if (preg_match('@^a:\d+:{@', $slice[$column])) {
+                    if (preg_match('@^a:\d+:{.*?}$@s', $slice[$column])) {
                         $value = \rex_var::toArray($slice[$column]);
                         if (is_array($value)) {
                             $sets[] = '`' . $column . '` = \'' . addslashes(json_encode($value)) . '\'';

--- a/lib/YConverter/Converter.php
+++ b/lib/YConverter/Converter.php
@@ -922,7 +922,7 @@ class Converter
                 for ($i = 1; $i <= 20; $i++) {
                     $column = 'value' . $i;
                     // Notices bei unserialize vermeiden
-                    if (preg_match('@^a:\d+:{.*?}$@', $slice[$column])) {
+                    if (preg_match('@^a:\d+:{@', $slice[$column])) {
                         $value = \rex_var::toArray($slice[$column]);
                         if (is_array($value)) {
                             $sets[] = '`' . $column . '` = \'' . addslashes(json_encode($value)) . '\'';


### PR DESCRIPTION
Ist der Inhalte einer Textarea mit Umbruch in einem serialisierten value enthalten greift der regex nicht und es findet kein Umbau nach json statt